### PR TITLE
Remove AnyObject restriction for `.diffUpdate`

### DIFF
--- a/Classes/Array+diffUpdate.swift
+++ b/Classes/Array+diffUpdate.swift
@@ -3,7 +3,7 @@
 // Copyright (C) 2019 MediaMonks. All rights reserved.
 //
 
-extension Array where Element: AnyObject {
+extension Array {
 
 	/**
 

--- a/MMMArrayChanges.podspec
+++ b/MMMArrayChanges.podspec
@@ -6,33 +6,33 @@
 Pod::Spec.new do |s|
 
 	s.name = "MMMArrayChanges"
-	s.version = "0.4.3"
+	s.version = "0.4.4"
 	s.summary = "Helps finding (UITableView-compatible) differences between two arrays possibly of different types"
 	s.description =  s.summary
 	s.homepage = "https://github.com/mediamonks/MMMArrayChanges"
 	s.license = "MIT"
 	s.authors = "MediaMonks"
 	s.source = { :git => "https://github.com/mediamonks/MMMArrayChanges.git", :tag => s.version.to_s }
-	
+
 	s.ios.deployment_target = '11.0'
 	s.watchos.deployment_target = '2.0'
 
-	s.subspec 'ObjC' do |ss|		
+	s.subspec 'ObjC' do |ss|
 		ss.source_files = [ 'Classes/*.{h,m}' ]
 	end
-	
+
 	s.swift_versions = '4.2'
-	s.static_framework = true	
+	s.static_framework = true
 	s.pod_target_xcconfig = {
 		"DEFINES_MODULE" => "YES"
-	}	
+	}
 	s.subspec 'Swift' do |ss|
-		ss.source_files = [ 'Classes/*.swift' ]	
+		ss.source_files = [ 'Classes/*.swift' ]
 	end
 
 	s.test_spec 'TestsSwift' do |test_spec|
 		test_spec.source_files = 'Tests/*.swift'
-	end  	
+	end
 
-	s.default_subspec = 'Swift'	
+	s.default_subspec = 'Swift'
 end


### PR DESCRIPTION
Having the `Array` extension limited to `AnyObject` makes it impossible for arrays of structs or type erased (that are not bound to inherit `AnyObject`) protocols to use the `diffUpdate` function.

**Use case**
```swift
protocol Foo {
  var id: String { get }
}

class Bar: Foo {
  public let id: String = "1"
}

struct Baz: Foo {
  public let id: String = "2"
}

let foos: [Foo] = [Bar(), Baz()]

foos.diffUpdate(...)
```

 Downside is that this does pollute the autocompletion for arrays of `[Int]` etc. Only way around this would be to have the `.diffUpdate` bound to a protocol, and have your protocol inherit from that;

```swift
protocol  MMMArrayChangeable {} // Find better naming for this

extension Array where Element: MMMArrayChangeable { ... }
```

However, this would be a breaking change, and would require MMMArrayChanges to be taken into v1.